### PR TITLE
Run Prettier Onsave

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "avoid"
+} 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,25 @@
     {
       "mode": "auto"
     }
-  ]
+  ],
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }


### PR DESCRIPTION
<!--
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### This PR is Part of a Series

- #...
- #...
- #...

-->

### TL;DR

Add Prettier configuration and VS Code settings for consistent code formatting across the project.

### Details

- Added `.prettierrc` with standard formatting rules:

  - Single quotes
  - 2 spaces indentation
  - 100 character line width
  - Trailing commas in ES5 mode
  - Semicolons required
  - Arrow function parentheses only when needed

- Updated VS Code settings to:
  - Enable format on save
  - Set Prettier as default formatter for TypeScript, JavaScript, JSON, and Markdown files
  - Configure automatic formatting for various file types

### How to Test

1. Install the Prettier VS Code extension if not already installed
2. Open any TypeScript, JavaScript, JSON, or Markdown file
3. Make some changes and save the file
4. Verify that the file is automatically formatted according to the Prettier rules

### GIF

![bob-ross-happy-accidents](https://github.com/user-attachments/assets/468f4969-c013-446e-9166-e3474c3765cd)
