### PR TITLE
feat: format shell scripts on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,8 @@
   },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[shellscript]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
   }
 }


### PR DESCRIPTION
<!--
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### This PR is Part of a Series

- #...
- #...
- #...

-->

### TL;DR

Added shell script formatting configuration to VS Code settings.

### Details

Added a new formatter configuration for shell scripts in `.vscode/settings.json`:

- Set `foxundermoon.shell-format` as the default formatter for shell scripts
- This ensures consistent formatting for shell script files in the project

### How to Test

1. Open any `.sh` file in VS Code
2. The file should automatically use the shell-format extension for formatting
3. Try formatting the file (Shift + Alt + F) to verify the formatter works

### GIF

![marcel-the-shell-with-shoes-on](https://github.com/user-attachments/assets/d5b03ec4-2841-4b7c-a812-af0f882aad3b)
