### PR TITLE
🟠 feat: smart clearing or stashing of filters when switching tabs / "types" of content

### DIFF
--- a/apps/f3-glossary/components/tag-filter.tsx
+++ b/apps/f3-glossary/components/tag-filter.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Filter, X } from 'lucide-react';
 import { getAllTags } from '@/lib/xicon';
+import { set } from 'date-fns';
 
 export function TagFilter() {
   const router = useRouter();
@@ -26,7 +27,9 @@ export function TagFilter() {
       const tags = await getAllTags();
       setTags(tags);
     })();
-  }, []);
+    setSelectedTags(searchParams.get('tags')?.split(',').filter(Boolean) || []);
+    setIsAnd(searchParams.get('tagsOperator') === 'AND');
+  }, [searchParams]);
 
   // Update URL when filters change
   const updateFilters = () => {

--- a/apps/f3-glossary/components/xicon-header.tsx
+++ b/apps/f3-glossary/components/xicon-header.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { SearchBar } from '@/components/search-bar';
 import { TagFilter } from '@/components/tag-filter';
 import { RegionFilter } from '@/components/region-filter';
+import { prepareParamsForTabSwitch } from '@/lib/prepare-tab-urls';
 
 export function XiconHeader() {
   const router = useRouter();
@@ -17,18 +18,17 @@ export function XiconHeader() {
   // Update URL when tab changes
   const handleTabChange = (value: string) => {
     const newTab = value as 'all' | 'exercise' | 'term' | 'article' | 'region';
+    const currentKind = searchParams.get('kind') || 'all';
+
     setActiveTab(newTab);
 
-    // Update URL
-    const params = new URLSearchParams(searchParams.toString());
+    const newParams = prepareParamsForTabSwitch({
+      currentTab: currentKind,
+      newTab,
+      searchParams,
+    });
 
-    if (newTab === 'all') {
-      params.delete('kind');
-    } else {
-      params.set('kind', newTab);
-    }
-
-    router.push(`/xicon?${params.toString()}`);
+    router.push(`/xicon?${newParams.toString()}`);
   };
 
   return (

--- a/apps/f3-glossary/lib/filter-stash.ts
+++ b/apps/f3-glossary/lib/filter-stash.ts
@@ -1,0 +1,34 @@
+// utils/filter-stash.ts
+
+type ExerciseFilter = {
+  tags: string[];
+  operator: 'AND' | 'OR';
+};
+
+type RegionFilter = {
+  state?: string;
+  city?: string;
+};
+
+let exerciseStash: ExerciseFilter = {
+  tags: [],
+  operator: 'OR',
+};
+
+let regionStash: RegionFilter = {};
+
+export function stashExerciseFilters(tags: string[], operator: 'AND' | 'OR') {
+  exerciseStash = { tags, operator };
+}
+
+export function getExerciseFilters(): ExerciseFilter {
+  return exerciseStash;
+}
+
+export function stashRegionFilters(state?: string, city?: string) {
+  regionStash = { state, city };
+}
+
+export function getRegionFilters(): RegionFilter {
+  return regionStash;
+}

--- a/apps/f3-glossary/lib/prepare-tab-urls.ts
+++ b/apps/f3-glossary/lib/prepare-tab-urls.ts
@@ -1,0 +1,62 @@
+// utils/prepare-tab-url.ts
+import {
+  stashExerciseFilters,
+  getExerciseFilters,
+  stashRegionFilters,
+  getRegionFilters,
+} from '@/lib/filter-stash';
+
+export function prepareParamsForTabSwitch({
+  currentTab,
+  newTab,
+  searchParams,
+}: {
+  currentTab: string;
+  newTab: string;
+  searchParams: URLSearchParams;
+}): URLSearchParams {
+  const params = new URLSearchParams(searchParams.toString());
+
+  // Stash and clear filters
+  if (currentTab === 'exercise') {
+    const tags = searchParams.get('tags')?.split(',').filter(Boolean) || [];
+    const operator = searchParams.get('tagsOperator') === 'AND' ? 'AND' : 'OR';
+    stashExerciseFilters(tags, operator);
+    params.delete('tags');
+    params.delete('tagsOperator');
+  }
+
+  if (currentTab === 'region') {
+    const state = searchParams.get('state') || undefined;
+    const city = searchParams.get('city') || undefined;
+    stashRegionFilters(state, city);
+    params.delete('state');
+    params.delete('city');
+  }
+
+  // Set new tab
+  if (newTab === 'all') {
+    params.delete('kind');
+  } else {
+    params.set('kind', newTab);
+  }
+
+  // Restore filters
+  if (newTab === 'exercise') {
+    const { tags, operator } = getExerciseFilters();
+    if (tags.length) {
+      params.set('tags', tags.join(','));
+    }
+    if (operator === 'AND') {
+      params.set('tagsOperator', 'AND');
+    }
+  }
+
+  if (newTab === 'region') {
+    const { state, city } = getRegionFilters();
+    if (state) params.set('state', state);
+    if (city) params.set('city', city);
+  }
+
+  return params;
+}


### PR DESCRIPTION
<!--
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
### This PR is Part of a Series

- #21
- #22 

### TL;DR

Add persistent filter stashing and restoration when switching between "exercise" and "region" tabs in the Xicon app. Improves UX by remembering filter selections per tab.

### Details

resolves https://github.com/pstaylor-patrick/f3-xicon/issues/8

- Introduced `filter-stash.ts` to store and retrieve filter state for exercises (tags, operator) and regions (state, city).
- Added `prepare-tab-urls.ts` to handle URL parameter logic when switching tabs, including stashing and restoring relevant filters.
- Updated `xicon-header.tsx` to use the new tab switch logic, ensuring filters are preserved per tab.
- Updated `tag-filter.tsx` to correctly initialize filter state from URL parameters.
- This change ensures that when users switch between "exercise" and "region" tabs, their filter selections are remembered and restored, rather than lost.

### How to Test

1. Go to the Xicon app and apply filters in the "exercise" tab (e.g., select tags, change AND/OR operator).
2. Switch to the "region" tab, apply region filters (state, city).
3. Switch back and forth between tabs. Each tab should remember its last filter state.
4. Confirm that the URL updates correctly and that filters are not lost when switching tabs.

### GIF

![clear](https://github.com/user-attachments/assets/e7412af4-8354-41d7-a5fe-e43155645f12)
