### PR TITLE
🟡 fix: pnpm format

### DIFF
--- a/apps/f3-glossary/app/page.tsx
+++ b/apps/f3-glossary/app/page.tsx
@@ -11,7 +11,10 @@ export default function Home() {
       </p>
 
       <Link href="/xicon">
-        <Button variant="default" className="bg-primary text-white hover:bg-primary/90 flex items-center gap-2">
+        <Button
+          variant="default"
+          className="bg-primary text-white hover:bg-primary/90 flex items-center gap-2"
+        >
           <Search className="h-4 w-4" />
           Start Searching
         </Button>

--- a/apps/f3-glossary/components/entry-layout.tsx
+++ b/apps/f3-glossary/components/entry-layout.tsx
@@ -46,11 +46,13 @@ export function EntryLayout({ entry, related, next, prev }: EntryLayoutProps) {
           <div className="mb-6 flex flex-wrap items-center gap-2">
             <Badge className={badgeColor}>{type}</Badge>
             {type === 'exercise' &&
-              tags?.filter(tag => tag).map(tag => (
-                <Badge key={tag} variant="outline" className="capitalize">
-                  {tag}
-                </Badge>
-              ))}
+              tags
+                ?.filter(tag => tag)
+                .map(tag => (
+                  <Badge key={tag} variant="outline" className="capitalize">
+                    {tag}
+                  </Badge>
+                ))}
           </div>
 
           <h1 className="mb-8 text-4xl font-bold tracking-tight">{title}</h1>

--- a/apps/f3-glossary/components/exercise-detail.tsx
+++ b/apps/f3-glossary/components/exercise-detail.tsx
@@ -35,7 +35,9 @@ export function ExerciseDetail({ entry, related, next, prev }: ExerciseDetailPro
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <div className="mb-6 flex flex-wrap items-center gap-2">
-            <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100">Exercise</Badge>
+            <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100">
+              Exercise
+            </Badge>
             {tags &&
               tags.filter(Boolean).map(tag => (
                 <Badge key={tag} variant="outline" className="capitalize">

--- a/apps/f3-glossary/components/related-items.tsx
+++ b/apps/f3-glossary/components/related-items.tsx
@@ -35,10 +35,7 @@ export function RelatedItems({ items, title, className = '' }: RelatedItemsProps
                   {item.text.substring(0, 100)}
                 </p>
                 <div className="mt-3">
-                  <Badge
-                    variant="secondary"
-                    className={badgeColor[item.type]}
-                  >
+                  <Badge variant="secondary" className={badgeColor[item.type]}>
                     {item.type}
                   </Badge>
                 </div>
@@ -51,4 +48,4 @@ export function RelatedItems({ items, title, className = '' }: RelatedItemsProps
       </div>
     </div>
   );
-} 
+}

--- a/apps/f3-glossary/components/term-detail.tsx
+++ b/apps/f3-glossary/components/term-detail.tsx
@@ -35,7 +35,9 @@ export function TermDetail({ entry, related, next, prev }: TermDetailProps) {
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <div className="mb-6">
-            <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100">Glossary Term</Badge>
+            <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100">
+              Glossary Term
+            </Badge>
           </div>
 
           <h1 className="mb-8 text-4xl font-bold tracking-tight">{title}</h1>

--- a/apps/f3-glossary/components/ui/checkbox.tsx
+++ b/apps/f3-glossary/components/ui/checkbox.tsx
@@ -18,8 +18,11 @@ const Checkbox = React.forwardRef<
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center',
-      'text-primary-foreground data-[state=checked]:text-white')}
+    <CheckboxPrimitive.Indicator
+      className={cn(
+        'flex items-center justify-center',
+        'text-primary-foreground data-[state=checked]:text-white'
+      )}
     >
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>


### PR DESCRIPTION
<!--
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### This PR is Part of a Series

- #...
- #...
- #...

-->

### TL;DR

ran `pnpm format` to fix formatting issues

### Details

This PR applies code formatting changes across several files in the `apps/f3-glossary` project using `pnpm format` (Prettier). The changes include:

- Breaking up long lines for better readability, especially for JSX props and children.
- Consistent indentation and alignment of props in component usage.
- Improved formatting of nested JSX elements and function calls.
- Ensuring a newline at the end of files where missing.
- No logic or functionality was changed—only formatting was affected.

### How to Test

1. Review the UI in the glossary app to ensure all components render as expected (no visual or functional regressions).
2. Run `pnpm format` locally to confirm there are no additional formatting changes needed.
3. Optionally, run the linter (`pnpm lint`) to verify code style compliance.
4. Check the diff to confirm only whitespace, indentation, and line breaks were changed (no logic or content changes).

### GIF

![but-prettier-than-that](https://github.com/user-attachments/assets/6204b9e2-b09d-4209-8089-3cc44dd92a48)
