### PR TITLE
fix and refactor badge colors

### DIFF
--- a/apps/f3-glossary/components/article-detail.tsx
+++ b/apps/f3-glossary/components/article-detail.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { XiconEntry } from '@/lib/xicon';
+import { badgeColor } from './xicon-card';
 
 interface ArticleDetailProps {
   entry: XiconEntry;
@@ -46,7 +47,7 @@ export function ArticleDetail({ entry, related, next, prev }: ArticleDetailProps
       <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
         <div className="md:col-span-2">
           <div className="mb-4 flex flex-wrap items-center gap-2">
-            <Badge className="bg-purple-100 text-purple-800">Article</Badge>
+            <Badge className={badgeColor.article}>Article</Badge>
             {quadrant && (
               <Badge variant="outline" className="capitalize">
                 {formatQuadrant(quadrant)}

--- a/apps/f3-glossary/components/entry-layout.tsx
+++ b/apps/f3-glossary/components/entry-layout.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { RelatedItems } from '@/components/related-items';
 import type { XiconEntry } from '@/lib/xicon';
+import { badgeColor } from './xicon-card';
 
 interface EntryLayoutProps {
   entry: XiconEntry;
@@ -15,14 +16,6 @@ interface EntryLayoutProps {
 
 export function EntryLayout({ entry, related, next, prev }: EntryLayoutProps) {
   const { title, text, tags, type, articleUrl, featuredImageUrl } = entry;
-
-  // Determine badge color based on type
-  const badgeColor = {
-    exercise: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100',
-    term: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100',
-    article: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-100',
-    region: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-100',
-  }[type];
 
   // Format text with basic markdown support
   const formatText = (text: string) => {
@@ -44,7 +37,7 @@ export function EntryLayout({ entry, related, next, prev }: EntryLayoutProps) {
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <div className="mb-6 flex flex-wrap items-center gap-2">
-            <Badge className={badgeColor}>{type}</Badge>
+            <Badge className={badgeColor[type]}>{type}</Badge>
             {type === 'exercise' &&
               tags
                 ?.filter(tag => tag)

--- a/apps/f3-glossary/components/exercise-detail.tsx
+++ b/apps/f3-glossary/components/exercise-detail.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { RelatedItems } from '@/components/related-items';
 import type { XiconEntry } from '@/lib/xicon';
+import { badgeColor } from './xicon-card';
 
 interface ExerciseDetailProps {
   entry: XiconEntry;
@@ -35,9 +36,7 @@ export function ExerciseDetail({ entry, related, next, prev }: ExerciseDetailPro
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <div className="mb-6 flex flex-wrap items-center gap-2">
-            <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100">
-              Exercise
-            </Badge>
+            <Badge className={badgeColor.exercise}>Exercise</Badge>
             {tags &&
               tags.filter(Boolean).map(tag => (
                 <Badge key={tag} variant="outline" className="capitalize">

--- a/apps/f3-glossary/components/region-detail.tsx
+++ b/apps/f3-glossary/components/region-detail.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { ChevronLeft, ChevronRight, MapPin } from 'lucide-react';
 import { RelatedItems } from '@/components/related-items';
 import type { XiconEntry } from '@/lib/xicon';
+import { badgeColor } from './xicon-card';
 
 const DEFAULT_WEBSITE_URL = 'https://freemensworkout.org/regions';
 const DEFAULT_MAP_URL = 'https://map.f3nation.com/';
@@ -31,9 +32,7 @@ export function RegionDetail({ entry, related, next, prev }: RegionDetailProps) 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <div className="mb-6">
-            <Badge className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100">
-              Region
-            </Badge>
+            <Badge className={badgeColor.region}>Region</Badge>
           </div>
 
           <h1 className="mb-8 text-4xl font-bold tracking-tight">{title}</h1>

--- a/apps/f3-glossary/components/search-bar.tsx
+++ b/apps/f3-glossary/components/search-bar.tsx
@@ -9,6 +9,7 @@ import { Search, X } from 'lucide-react';
 import { useDebounce } from '@/hooks/use-debounce';
 import { getFilteredXicons } from '@/lib/xicon';
 import type { XiconEntry } from '@/lib/xicon';
+import { badgeColor } from './xicon-card';
 
 export function SearchBar() {
   const router = useRouter();
@@ -132,13 +133,7 @@ export function SearchBar() {
                 </div>
                 <div className="mt-1 flex items-center gap-2">
                   <span
-                    className={`text-xs px-2 py-0.5 rounded-full ${
-                      suggestion.type === 'exercise'
-                        ? 'bg-blue-100 text-blue-800'
-                        : suggestion.type === 'term'
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-purple-100 text-purple-800'
-                    }`}
+                    className={`text-xs px-2 py-0.5 rounded-full ${badgeColor[suggestion.type]}`}
                   >
                     {suggestion.type}
                   </span>

--- a/apps/f3-glossary/components/term-detail.tsx
+++ b/apps/f3-glossary/components/term-detail.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { RelatedItems } from '@/components/related-items';
 import type { XiconEntry } from '@/lib/xicon';
+import { badgeColor } from './xicon-card';
 
 interface TermDetailProps {
   entry: XiconEntry;
@@ -35,9 +36,7 @@ export function TermDetail({ entry, related, next, prev }: TermDetailProps) {
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <div className="mb-6">
-            <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100">
-              Glossary Term
-            </Badge>
+            <Badge className={badgeColor.term}>Glossary Term</Badge>
           </div>
 
           <h1 className="mb-8 text-4xl font-bold tracking-tight">{title}</h1>


### PR DESCRIPTION
# fix and refactor badge colors

<!--
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### This PR is Part of a Series

- #...
- #...
- #...

-->

### TL;DR

Refactored badge color logic for glossary item types (exercise, term, article, region) into a single `badgeColor` object, and updated all components to use it for consistent, maintainable styling.

### Details

- Centralized badge color classes for all glossary types in `xicon-card.tsx` as a `badgeColor` object.
- Updated all components that display badges (ArticleDetail, EntryLayout, ExerciseDetail, RegionDetail, TermDetail, SearchBar, RelatedItems) to use `badgeColor` for type-based coloring.
- Removed hardcoded color classes and duplicate logic from individual components.
- Ensures consistent badge appearance and makes future color changes easier.
- No changes to the Badge component itself; only how color classes are assigned.

### How to Test

1. Visit glossary pages for exercises, terms, articles, and regions.
2. Confirm that badges for each type use the correct color (see `badgeColor` in `xicon-card.tsx`).
3. Check badge colors in search suggestions and related items.
4. Verify that all badge colors are consistent across light and dark mode.
5. Confirm there are no visual regressions or missing badges.

### GIF

![monsters-inc-boo-beating-lizard-into-diff-colors](https://github.com/user-attachments/assets/10c506e5-bf25-4f26-9863-6a611b72941b)
