### PR TITLE
ingest lexicon terms and exicon exercises

### DIFF
--- a/apps/f3-glossary/scripts/db/items/seed/.gitignore
+++ b/apps/f3-glossary/scripts/db/items/seed/.gitignore
@@ -1,0 +1,1 @@
+items.json

--- a/apps/f3-glossary/scripts/db/items/seed/.gitignore
+++ b/apps/f3-glossary/scripts/db/items/seed/.gitignore
@@ -1,1 +1,2 @@
-items.json
+lexicon.json
+exicon.json

--- a/apps/f3-glossary/scripts/db/items/seed/index.ts
+++ b/apps/f3-glossary/scripts/db/items/seed/index.ts
@@ -1,80 +1,43 @@
 import { db } from '@/drizzle/db';
 import { itemsSchema } from '@/drizzle/schemas';
+import { kebabCase } from 'lodash';
+
+const GOOGLE_SHEETS_JSON_URL_ITEMS =
+  'https://sheets.googleapis.com/v4/spreadsheets/176smbOvZkK5AJJR034ZEgtbbflIVqySAc4sy8aiK46Y/values/Lexicon?key=AIzaSyCUFLnGh5pHkqh3TjPsJD-8hOZwGlxvRwQ';
 
 export async function seedItems() {
-  await db
-    .insert(itemsSchema)
-    .values([
-      {
-        slug: 'exercise-1',
-        type: 'exercise',
-        name: 'Exercise 1',
-        description: 'This is the description of exercise 1',
-        tags: ['tag1', 'tag2'],
-      },
-      {
-        slug: 'exercise-2',
-        type: 'exercise',
-        name: 'Exercise 2',
-        description: 'This is the description of exercise 2',
-        tags: ['tag3', 'tag4'],
-      },
-      {
-        slug: 'exercise-3',
-        type: 'exercise',
-        name: 'Exercise 3',
-        description: 'This is the description of exercise 3',
-        tags: ['tag5', 'tag6'],
-      },
-      {
-        slug: 'exercise-4',
-        type: 'exercise',
-        name: 'Exercise 4',
-        description: 'This is the description of exercise 4',
-        tags: ['tag7', 'tag8'],
-      },
-      {
-        slug: 'exercise-5',
-        type: 'exercise',
-        name: 'Exercise 5',
-        description: 'This is the description of exercise 5',
-        tags: ['tag9', 'tag10'],
-      },
-      {
-        slug: 'term-1',
-        type: 'term',
-        name: 'Term 1',
-        description: 'This is the description of term 1',
-        tags: ['tag11', 'tag12'],
-      },
-      {
-        slug: 'term-2',
-        type: 'term',
-        name: 'Term 2',
-        description: 'This is the description of term 2',
-        tags: ['tag13', 'tag14'],
-      },
-      {
-        slug: 'term-3',
-        type: 'term',
-        name: 'Term 3',
-        description: 'This is the description of term 3',
-        tags: ['tag15', 'tag16'],
-      },
-      {
-        slug: 'term-4',
-        type: 'term',
-        name: 'Term 4',
-        description: 'This is the description of term 4',
-        tags: ['tag17', 'tag18'],
-      },
-      {
-        slug: 'term-5',
-        type: 'term',
-        name: 'Term 5',
-        description: 'This is the description of term 5',
-        tags: ['tag19', 'tag20'],
-      },
-    ])
-    .onConflictDoNothing();
+  console.debug('seeding items');
+  const items = await fetchItems();
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    console.debug(`seeding item ${i + 1} of ${items.length}: ${item.type}: ${item.slug}`);
+    await db.insert(itemsSchema).values(item).onConflictDoNothing();
+  }
+  console.debug('done seeding items');
 }
+
+async function fetchItems(): Promise<Item[]> {
+  const itemsRes = await fetch(GOOGLE_SHEETS_JSON_URL_ITEMS);
+  const itemsJson = (await itemsRes.json()) as ItemsResponse;
+  const items = itemsJson.values.slice(1).map(i => {
+    const title = i[0].trim();
+    const text = i[1].trim();
+    return {
+      slug: kebabCase(title),
+      type: 'term',
+      name: title,
+      description: text,
+      tags: [],
+    } as Item;
+  });
+  items.sort((a, b) => a.slug.localeCompare(b.slug));
+  return items;
+}
+
+type Item = typeof itemsSchema.$inferInsert;
+
+type ItemsResponse = {
+  range: string;
+  majorDimension: 'ROWS';
+  values: string[][];
+};


### PR DESCRIPTION
<!--
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### This PR is Part of a Series

- #...
- #...
- #...

-->

### TL;DR

This PR updates the seeding logic to ingest Lexicon terms and Exicon exercises directly from Google Sheets into the database, replacing static seed data with dynamic fetching and mapping.

### Details

- Adds functions to fetch Lexicon terms and Exicon exercises from Google Sheets using the Sheets API.
- Maps the fetched data to the `itemsSchema` format, generating slugs and parsing tags as needed.
- Seeds the database with the combined and sorted items, handling both terms and exercises.
- Removes hardcoded seed data in favor of dynamic ingestion from the external source.

### How to Test

1. Change to the glossary app directory:
   ```sh
   cd apps/f3-glossary
   ```
2. Run the seed script:
   ```sh
   pnpm db:seed:items
   ```
3. Check the database to ensure that items from both the Lexicon and Exicon Google Sheets are present, with correct slugs, types, names, descriptions, and tags.
4. Review logs for successful seeding and any errors.

### GIF

![80s-exercises](https://github.com/user-attachments/assets/b8cad6cd-1435-454e-976b-5ebe4906df7c)
