### PR TITLE
fix typos (broken tab filters)

### DIFF
--- a/apps/f3-glossary/app/page.tsx
+++ b/apps/f3-glossary/app/page.tsx
@@ -90,7 +90,7 @@ export default function XiconPage() {
       params.set('kind', newTab);
     }
 
-    window.history.pushState({}, '', `/xicon?${params.toString()}`);
+    window.history.pushState({}, '', `/?${params.toString()}`);
   };
 
   return (

--- a/apps/f3-glossary/components/article-detail.tsx
+++ b/apps/f3-glossary/components/article-detail.tsx
@@ -40,7 +40,7 @@ export function ArticleDetail({ entry, related, next, prev }: ArticleDetailProps
   return (
     <div className="container mx-auto px-4 py-6">
       <div className="mb-6">
-        <Link href="/xicon" className="text-gray-500 hover:text-gray-700">
+        <Link href="/" className="text-gray-500 hover:text-gray-700">
           ← Back to search
         </Link>
       </div>

--- a/apps/f3-glossary/components/entry-layout.tsx
+++ b/apps/f3-glossary/components/entry-layout.tsx
@@ -29,7 +29,7 @@ export function EntryLayout({ entry, related, next, prev }: EntryLayoutProps) {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8">
-        <Link href="/xicon" className="text-muted-foreground hover:text-foreground">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
           ← Back to search
         </Link>
       </div>

--- a/apps/f3-glossary/components/exercise-detail.tsx
+++ b/apps/f3-glossary/components/exercise-detail.tsx
@@ -28,7 +28,7 @@ export function ExerciseDetail({ entry, related, next, prev }: ExerciseDetailPro
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8">
-        <Link href="/xicon" className="text-muted-foreground hover:text-foreground">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
           ← Back to search
         </Link>
       </div>

--- a/apps/f3-glossary/components/region-detail.tsx
+++ b/apps/f3-glossary/components/region-detail.tsx
@@ -24,7 +24,7 @@ export function RegionDetail({ entry, related, next, prev }: RegionDetailProps) 
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8">
-        <Link href="/xicon" className="text-muted-foreground hover:text-foreground">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
           ← Back to search
         </Link>
       </div>

--- a/apps/f3-glossary/components/region-filter.tsx
+++ b/apps/f3-glossary/components/region-filter.tsx
@@ -64,7 +64,7 @@ export function RegionFilter() {
       params.delete('country');
     }
 
-    router.push(`/xicon?${params.toString()}`);
+    router.push(`/?${params.toString()}`);
     setOpen(false);
   };
 
@@ -78,7 +78,7 @@ export function RegionFilter() {
     params.delete('state');
     params.delete('city');
 
-    router.push(`/xicon?${params.toString()}`);
+    router.push(`/?${params.toString()}`);
     setOpen(false);
   };
 

--- a/apps/f3-glossary/components/search-bar.tsx
+++ b/apps/f3-glossary/components/search-bar.tsx
@@ -63,7 +63,7 @@ export function SearchBar() {
       params.delete('q');
     }
 
-    router.push(`/xicon?${params.toString()}`);
+    router.push(`/?${params.toString()}`);
     setShowSuggestions(false);
   };
 
@@ -85,7 +85,7 @@ export function SearchBar() {
     setQuery('');
     const params = new URLSearchParams(searchParams.toString());
     params.delete('q');
-    router.push(`/xicon?${params.toString()}`);
+    router.push(`/?${params.toString()}`);
   };
 
   return (

--- a/apps/f3-glossary/components/tag-filter.tsx
+++ b/apps/f3-glossary/components/tag-filter.tsx
@@ -47,7 +47,7 @@ export function TagFilter() {
       params.delete('tagsOperator');
     }
 
-    router.push(`/xicon?${params.toString()}`);
+    router.push(`/?${params.toString()}`);
     setOpen(false);
   };
 
@@ -65,7 +65,7 @@ export function TagFilter() {
     params.delete('tags');
     params.delete('tagsOperator');
 
-    router.push(`/xicon?${params.toString()}`);
+    router.push(`/?${params.toString()}`);
     setOpen(false);
   };
 

--- a/apps/f3-glossary/components/term-detail.tsx
+++ b/apps/f3-glossary/components/term-detail.tsx
@@ -28,7 +28,7 @@ export function TermDetail({ entry, related, next, prev }: TermDetailProps) {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8">
-        <Link href="/xicon" className="text-muted-foreground hover:text-foreground">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
           ← Back to search
         </Link>
       </div>

--- a/apps/f3-glossary/components/xicon-header.tsx
+++ b/apps/f3-glossary/components/xicon-header.tsx
@@ -30,7 +30,7 @@ export function XiconHeader() {
       searchParams,
     });
 
-    router.push(`/xicon?${newParams.toString()}`);
+    router.push(`/?${newParams.toString()}`);
   };
 
   return (


### PR DESCRIPTION
<!--
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### This PR is Part of a Series

- #...
- #...
- #...

-->

### TL;DR

Fixed broken tab filters and navigation in the glossary app by correcting URL paths from `/xicon?...` to `/?...`.

### Details

This PR fixes a bug introduced by PR #37, where navigation and filter actions (such as tab filters, search, and region/tag filters) were using the wrong URL path (`/xicon?...` instead of `/?...`). This caused the filters and navigation to break or not update the UI as expected. All relevant components now use the correct root path, restoring expected behavior.

### How to Test

1. Open the glossary app.
2. Use the tab filters, search bar, region filter, and tag filter.
3. Confirm that the URL updates correctly (should use `/?...` instead of `/xicon?...`).
4. Navigate to detail pages and use the "Back to search" link; it should return you to the main search page.
5. Verify that all navigation and filtering actions work as expected without errors.

### GIF

![ron-swanson-im-sure-youll-figure-it-out](https://github.com/user-attachments/assets/f5df75c6-3b0c-4801-a160-28d931c6275d)
