### PR TITLE
fix region city state filters

### DIFF
--- a/apps/f3-glossary/components/xicon-list.tsx
+++ b/apps/f3-glossary/components/xicon-list.tsx
@@ -29,6 +29,9 @@ export function XiconList() {
       tags: searchParams.get('tags')?.split(',').filter(Boolean) || [],
       query: searchParams.get('q') || '',
       tagsOperator: (searchParams.get('tagsOperator') as 'AND' | 'OR') || 'OR',
+      country: searchParams.get('country') || '',
+      state: searchParams.get('state') || '',
+      city: searchParams.get('city') || '',
     };
 
     setPage(1);

--- a/apps/f3-glossary/lib/filter-stash.ts
+++ b/apps/f3-glossary/lib/filter-stash.ts
@@ -6,6 +6,7 @@ type ExerciseFilter = {
 };
 
 type RegionFilter = {
+  country?: string;
   state?: string;
   city?: string;
 };
@@ -25,8 +26,8 @@ export function getExerciseFilters(): ExerciseFilter {
   return exerciseStash;
 }
 
-export function stashRegionFilters(state?: string, city?: string) {
-  regionStash = { state, city };
+export function stashRegionFilters(country?: string, state?: string, city?: string) {
+  regionStash = { country, state, city };
 }
 
 export function getRegionFilters(): RegionFilter {

--- a/apps/f3-glossary/lib/prepare-tab-urls.ts
+++ b/apps/f3-glossary/lib/prepare-tab-urls.ts
@@ -27,9 +27,11 @@ export function prepareParamsForTabSwitch({
   }
 
   if (currentTab === 'region') {
+    const country = searchParams.get('country') || undefined;
     const state = searchParams.get('state') || undefined;
     const city = searchParams.get('city') || undefined;
-    stashRegionFilters(state, city);
+    stashRegionFilters(country, state, city);
+    params.delete('country');
     params.delete('state');
     params.delete('city');
   }
@@ -53,7 +55,8 @@ export function prepareParamsForTabSwitch({
   }
 
   if (newTab === 'region') {
-    const { state, city } = getRegionFilters();
+    const { country, state, city } = getRegionFilters();
+    if (country) params.set('country', country);
     if (state) params.set('state', state);
     if (city) params.set('city', city);
   }

--- a/apps/f3-glossary/lib/xicon.ts
+++ b/apps/f3-glossary/lib/xicon.ts
@@ -9,6 +9,7 @@ export type XiconFilter = {
   tags?: string[];
   query?: string;
   tagsOperator?: 'AND' | 'OR';
+  country?: string;
   city?: string;
   state?: string;
 };
@@ -96,12 +97,21 @@ export async function getFilteredXicons(filter: XiconFilter): Promise<XiconItem[
     });
   }
 
+  // Filter by country (for regions)
+  if (filter.country) {
+    const countryLower = filter.country.toLowerCase();
+    items = items.filter(item => {
+      if (item.type !== 'region') return true;
+      return item.country?.toLowerCase() === countryLower;
+    });
+  }
+
   // Filter by city (for regions)
   if (filter.city) {
     const cityLower = filter.city.toLowerCase();
     items = items.filter(item => {
       if (item.type !== 'region') return true;
-      return item.city?.toLowerCase().includes(cityLower);
+      return item.city?.toLowerCase() === cityLower;
     });
   }
 
@@ -110,7 +120,7 @@ export async function getFilteredXicons(filter: XiconFilter): Promise<XiconItem[
     const stateLower = filter.state.toLowerCase();
     items = items.filter(item => {
       if (item.type !== 'region') return true;
-      return item.state?.toLowerCase().includes(stateLower);
+      return item.state?.toLowerCase() === stateLower;
     });
   }
 


### PR DESCRIPTION
<!--
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### This PR is Part of a Series

- #...
- #...
- #...

-->

### TL;DR

Fixes and improves region, city, state, and country filters for the glossary. Filters now match exactly and persist correctly when switching tabs.

### Details

resolves issue #43 

- Added support for filtering by country in addition to state and city.
- Changed city and state filters to require exact matches (instead of partial).
- Updated filter stash logic to include country, and to persist all three (country, state, city) when switching tabs.
- Updated parameter handling so that region filters are correctly set and cleared as needed.
- Improved the overall reliability of region-based filtering in the glossary UI.

### How to Test

1. Go to: http://localhost:3000/?kind=region&city=Columbia
2. Try filtering by country, state, and city in the UI and verify that the results match exactly.
3. Switch between tabs (e.g., region, other tabs) and confirm that your region filters persist and restore as expected.
4. Check that the correct results are shown for various combinations of country, state, and city.

http://localhost:3000/?kind=region&city=Columbia

<img width="1398" alt="Screenshot 2025-06-04 at 05 18 25" src="https://github.com/user-attachments/assets/2ee01656-1bca-46b8-a2a7-e8074d9163f9" />

### GIF

![john-crist-map-confused](https://github.com/user-attachments/assets/9c7d1398-090f-48aa-9719-06839fafc989)
